### PR TITLE
Specify shade plugin version

### DIFF
--- a/trade-monitor-ui/pom.xml
+++ b/trade-monitor-ui/pom.xml
@@ -32,6 +32,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
Some training attendees had problems with running the project in Idea IDE because of "missing" shade-plugin.