### PR TITLE
allow to write pipeline oprators after described steps

### DIFF
--- a/essentials/src/main/java/Lab2.java
+++ b/essentials/src/main/java/Lab2.java
@@ -48,7 +48,6 @@ public class Lab2 {
 
         p.readFrom(source)
          .withoutTimestamps()
-         .writeTo(Sinks.observable(MY_JOB_RESULTS));
 
         // STEP 1: Filter out odd numbers from the stream
 
@@ -78,6 +77,7 @@ public class Lab2 {
 
         // Stop the job
 
+         .writeTo(Sinks.observable(MY_JOB_RESULTS));
 
         return p;
     }


### PR DESCRIPTION
It feels more natural to me to write code right after the describe steps in comments. Same idea I noticed in other Labs classes