### PR TITLE
Replace versioned Hazelcast docs with `latest`

### DIFF
--- a/Lab4.md
+++ b/Lab4.md
@@ -62,7 +62,7 @@ stream.
 #### 2. Learn about routing events
 
 Although there is only one node, in general there will be multiple. Take a 
-moment to review the documentation on [parallel processing](https://docs.hazelcast.com/hazelcast/5.3/architecture/distributed-computing#parallel-processing). As 
+moment to review the documentation on [parallel processing](https://docs.hazelcast.com/hazelcast/latest/architecture/distributed-computing#parallel-processing). As 
 you can see, each job is described by a directed acyclic graph (DAG) of tasks.  
 Because Hazelcast is data location-aware, or "partition aware", it directs 
 the execution of tasks so as to reduce data movement.  

--- a/Lab6.md
+++ b/Lab6.md
@@ -67,7 +67,7 @@ Modify the window definition to publish intermediate results every second.
 
 The intermediate results can be counter-intuitive and it's worth spending some time to 
 understand what's really going on.  The key is to understand that _event time is not 
-related to the actual time_.   See [this discussion](https://docs.hazelcast.com/hazelcast/5.3/pipelines/building-pipelines#event-disorder) 
+related to the actual time_.   See [this discussion](https://docs.hazelcast.com/hazelcast/latest/pipelines/building-pipelines#event-disorder) 
 of how Hazelcast keeps track of the "event time" within the stream, which is separate from 
 "processing time".  
 

--- a/Lab7.md
+++ b/Lab7.md
@@ -118,12 +118,12 @@ connection.  There are _many_ ways to configure a client.  The
 recommended approach is to use 
 `HazelcastClient.newHazelcastClient()` which follows a documented 
 process for finding a client configuration. See 
-[the documentation page](https://docs.hazelcast.com/hazelcast/5.3/configuration/understanding-configuration)
+[the documentation page](https://docs.hazelcast.com/hazelcast/latest/configuration/understanding-configuration)
 , especially "Configuration Precedence".  For this lab, a client configuration file has 
 been provided: `hazelcast-client.yaml`
 
 Also, when a client submits a job, it needs to attach all  required
-classes using [JobConfig.addClass](https://docs.hazelcast.org/docs/5.3.5/javadoc/com/hazelcast/jet/config/JobConfig.html).
+classes using [JobConfig.addClass](https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/jet/config/JobConfig.html).
 When using CLC, this is taken care of automatically.
 
 Complete the code by following the instructions in `Lab7.java` then 


### PR DESCRIPTION
Updated existing Hazelcast `5.x` documentation links to use `latest` instead