### PR TITLE
Update docs links, prepare for 5.5 release

### DIFF
--- a/Lab3.md
+++ b/Lab3.md
@@ -29,10 +29,10 @@ events out to the `latest_trade` map.
 
 #### 1. read events from the `trades` IMap
 
-Read the javadoc for the [Sources.mapJournal](https://docs.hazelcast.org/docs/5.3.5/javadoc/com/hazelcast/jet/pipeline/Sources.html#mapJournal-java.lang.String-com.hazelcast.jet.pipeline.JournalInitialPosition-).  
+Read the javadoc for the [Sources.mapJournal](https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/jet/pipeline/Sources.html#mapJournal-java.lang.String-com.hazelcast.jet.pipeline.JournalInitialPosition-).  
 
 When ingesting events, you must specify _when_ the event happened using 
-one of the methods of [StreamSourceStage](https://docs.hazelcast.org/docs/5.3.5/javadoc/com/hazelcast/jet/pipeline/StreamSourceStage.html).
+one of the methods of [StreamSourceStage](https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/jet/pipeline/StreamSourceStage.html).
 
 It is important to remember that the time the event actually occurred is often not the same as the time it is ingested.  This creates 
 many issues.  You can find a good discussion here: [Event Timestamps](https://docs.hazelcast.com/hazelcast/latest/pipelines/building-pipelines#event-timestamps). 
@@ -42,7 +42,7 @@ late events to arrive.
 
 #### 2. change  `Map.Entry<Integer, Trade>` into Tuple2<String, Trade>
 
-See the javadoc for [Tuple2](https://docs.hazelcast.org/docs/5.3.5/javadoc/com/hazelcast/jet/datamodel/Tuple2.html). Note that it 
+See the javadoc for [Tuple2](https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/jet/datamodel/Tuple2.html). Note that it 
 implements `Map.Entry`.  A `Tuple2` can be written directly to an `IMap` 
 so this step will output a `Tuple2`.
 
@@ -53,7 +53,7 @@ with `symbol` as the key.
 
 #### 3. Write the result to the `latest_trade` map. 
 
-See [Sinks.map](https://docs.hazelcast.org/docs/5.3.5/javadoc/com/hazelcast/jet/pipeline/Sinks.html#map-java.lang.String-) 
+See [Sinks.map](https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/jet/pipeline/Sinks.html#map-java.lang.String-) 
 
 ## Ideas for Extra Practice
 

--- a/Lab3.md
+++ b/Lab3.md
@@ -29,7 +29,7 @@ events out to the `latest_trade` map.
 
 #### 1. read events from the `trades` IMap
 
-Read the javadoc for the [Sources.mapJournal](https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/jet/pipeline/Sources.html#mapJournal-java.lang.String-com.hazelcast.jet.pipeline.JournalInitialPosition-).  
+Read the javadoc for the [Sources.mapJournal](https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/jet/pipeline/Sources.html#mapJournal(java.lang.String,com.hazelcast.jet.pipeline.JournalInitialPosition)).  
 
 When ingesting events, you must specify _when_ the event happened using 
 one of the methods of [StreamSourceStage](https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/jet/pipeline/StreamSourceStage.html).
@@ -53,7 +53,7 @@ with `symbol` as the key.
 
 #### 3. Write the result to the `latest_trade` map. 
 
-See [Sinks.map](https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/jet/pipeline/Sinks.html#map-java.lang.String-) 
+See [Sinks.map](https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/jet/pipeline/Sinks.html#map(java.lang.String)) 
 
 ## Ideas for Extra Practice
 

--- a/Lab4.md
+++ b/Lab4.md
@@ -87,7 +87,7 @@ on a 2 machine cluster with each member having 2 cores.
 
 #### 3. Perform enrichment using `StreamStage.mapUsingIMap`
 
-Review the documentation for [StreamStage.mapUsingIMap](https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/jet/pipeline/StreamStage.html?mapUsingIMap-java.lang.String-com.hazelcast.function.FunctionEx-com.hazelcast.function.BiFunctionEx-), then add a stage to the pipeline to do the 
+Review the documentation for [StreamStage.mapUsingIMap](https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/jet/pipeline/StreamStage.html#mapUsingIMap(java.lang.String,com.hazelcast.function.FunctionEx,com.hazelcast.function.BiFunctionEx)), then add a stage to the pipeline to do the 
 enhancement.  
 
 > __HINT:__ `mapUsingIMap` takes 3 _type_ parameters.  You may need to explicitly 

--- a/Lab4.md
+++ b/Lab4.md
@@ -87,7 +87,7 @@ on a 2 machine cluster with each member having 2 cores.
 
 #### 3. Perform enrichment using `StreamStage.mapUsingIMap`
 
-Review the documentation for [StreamStage.mapUsingIMap](https://docs.hazelcast.org/docs/5.3.5/javadoc/com/hazelcast/jet/pipeline/StreamStage.html?mapUsingIMap-java.lang.String-com.hazelcast.function.FunctionEx-com.hazelcast.function.BiFunctionEx-), then add a stage to the pipeline to do the 
+Review the documentation for [StreamStage.mapUsingIMap](https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/jet/pipeline/StreamStage.html?mapUsingIMap-java.lang.String-com.hazelcast.function.FunctionEx-com.hazelcast.function.BiFunctionEx-), then add a stage to the pipeline to do the 
 enhancement.  
 
 > __HINT:__ `mapUsingIMap` takes 3 _type_ parameters.  You may need to explicitly 

--- a/Lab5.md
+++ b/Lab5.md
@@ -26,15 +26,15 @@ changed by 25% or more.
 
 ## Instructions
 
-First, read the java doc on [StreamStageWithKey.mapStateful](https://docs.hazelcast.org/docs/5.3.5/javadoc/com/hazelcast/jet/pipeline/StreamStageWithKey.html#mapStateful-com.hazelcast.function.SupplierEx-com.hazelcast.jet.function.TriFunction-).  
+First, read the java doc on [StreamStageWithKey.mapStateful](https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/jet/pipeline/StreamStageWithKey.html#mapStateful(com.hazelcast.function.SupplierEx,com.hazelcast.jet.function.TriFunction)).  
 
 Note that the platform will automatically use the create function you provide 
 to create a state object _for each grouping key_.  You can convert a regular 
-`StreamStage` into a `StreamStageWithKey` using [StreamStage.groupingKey](https://docs.hazelcast.org/docs/5.3.5/javadoc/com/hazelcast/jet/pipeline/StreamStage.html#groupingKey-com.hazelcast.function.FunctionEx-).
+`StreamStage` into a `StreamStageWithKey` using [StreamStage.groupingKey](https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/jet/pipeline/StreamStage.html#groupingKey(com.hazelcast.function.FunctionEx)).
 
 Hazelcast provides a number of useful state objects in the 
 `com.hazelcast.jet.accumulator` package.  For this lab, we can use 
-[LongAccumulator](https://docs.hazelcast.org/docs/5.3.5/javadoc/com/hazelcast/jet/accumulator/LongAccumulator.html).  You are also 
+[LongAccumulator](https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/jet/accumulator/LongAccumulator.html).  You are also 
 free to use your own state object so long as it is serializable.
 
 #### 1. Use the `StreamStage.groupingKey` method to create a `StreamStageWithKey`

--- a/Lab6.md
+++ b/Lab6.md
@@ -5,9 +5,9 @@ platform.  Aggregation is a 3-step process:
 1. __Define a grouping key.__  Generally we don't want to aggregate ALL 
 of the events, we want to aggregate by something like `customer_id`.   
 2. __Define the Window__.  This describes _how much_ data to aggregate. See
-the javadoc for [WindowDefinition](https://docs.hazelcast.org/docs/5.3.5/javadoc/com/hazelcast/jet/pipeline/WindowDefinition.html).
+the javadoc for [WindowDefinition](https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/jet/pipeline/WindowDefinition.html).
 3. __Define the aggregation operation__, for example count or sum.  Many 
-aggregating operations are provided by the [AggregateOperations](https://docs.hazelcast.org/docs/5.3.5/javadoc/com/hazelcast/jet/aggregate/AggregateOperations.html) class.  It is also possible to define custom aggregations but that
+aggregating operations are provided by the [AggregateOperations](https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/jet/aggregate/AggregateOperations.html) class.  It is also possible to define custom aggregations but that
 is not covered in this lab.
 
 An example of counting the number of trades in a 3 second window is shown below  

--- a/Lab7.md
+++ b/Lab7.md
@@ -109,7 +109,7 @@ deploy a job programmatically.  That is what we will do in this part.
 
 Also, there is a special `Sink` which can be used to stream the results 
 of a job back  to a client. First read the documentation for 
-[Sinks.observable](https://docs.hazelcast.org/docs/5.3.5/javadoc/com/hazelcast/jet/pipeline/Sinks.html#observable-com.hazelcast.jet.Observable-)
+[Sinks.observable](https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/jet/pipeline/Sinks.html#observable(com.hazelcast.jet.Observable))
  modify the lab 7 code to send the results back to the client.
 
 Note that in this case, you will not be able to rely on CLC for the 

--- a/hazelcast-client.yaml
+++ b/hazelcast-client.yaml
@@ -7,5 +7,6 @@ hazelcast-client:
     cluster-members:
       - localhost:5701
 
-    # disable smart routing because only one member is reachable
-    smart-routing: false
+    # use single member routing because only one member is reachable
+    cluster-routing:
+      mode: SINGLE_MEMBER

--- a/hazelcast-platform-labs/src/main/java/Lab7.java
+++ b/hazelcast-platform-labs/src/main/java/Lab7.java
@@ -33,14 +33,14 @@ public class Lab7 {
 
         // 2. register a new observable with Jet and a new Observer on the Observable
         //    The Observer should just print the received event to the console
-        //    See https://docs.hazelcast.org/docs/5.3.5/javadoc/com/hazelcast/jet/JetService.html#newObservable--
+        //    See https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/jet/JetService.html#newObservable()
 
 
         // 3. Pass the Observable created above into the buildPipeline method so it can be incorporated into the Pipeline
         Pipeline p = buildPipeline();
 
         // 4. Since the job is being deployed by this client rather than CLC, we must add the necessary classes to the
-        //    job's class path via [JobConfig.addClass](https://docs.hazelcast.org/docs/5.3.5/javadoc/com/hazelcast/jet/config/JobConfig.html)
+        //    job's class path via [JobConfig.addClass](https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/jet/config/JobConfig.html)
         Job job = hz.getJet().newJob(p);
 
         // 5.  Since this job is meant to be used only by this client, cancel it when this client exits

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
-        <hazelcast.version>5.3.5</hazelcast.version>
+        <hazelcast.version>5.5.0</hazelcast.version>
         <log4j.version>1.2.17</log4j.version>
     </properties>
 


### PR DESCRIPTION
This PR updates documentation links to use `/latest/` instead of version specific documentation, as it makes maintenance of this repository easier.

It also prepares for the 5.5 release by updating the `hazelcast.version` property and using `cluster-routing` instead of `smart-routing` configuration on clients.

**This PR should not be merged until 5.5 has been released!**